### PR TITLE
Re-index logo images to 1-5 instead of 1-6

### DIFF
--- a/static/js/layout/controllers/home.controller.js
+++ b/static/js/layout/controllers/home.controller.js
@@ -25,7 +25,7 @@
         $scope.isLoggedIn = Authentication.isAuthenticated();
         $scope.account = Authentication.getAuthenticatedAccount();
 
-        $scope.randomImg = 1+Math.floor(Math.random() * 6);
+        $scope.randomImg = 1+Math.floor(Math.random() * 5);
 
         $scope.data = {
             'reddit': [{


### PR DESCRIPTION
We had removed logo image 3 because it was mostly ocean:
![image3](https://user-images.githubusercontent.com/249285/31585934-f56b0396-b17e-11e7-8a4a-b14c5ff2b260.png)

And we renumbered the remaining images from image1-image6 to image1-image5. But the random logo generation on the homepage was still indexing all six logos. That resulted in a broken link 1/6th of the time:
<img width="649" alt="screen shot 2017-10-15 at 8 00 39 am" src="https://user-images.githubusercontent.com/249285/31585939-00ededa0-b17f-11e7-8dc0-32675932c974.png">

I changed it to only index 1-5, which should fix this.